### PR TITLE
Fix string offset in firmware version request

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,8 @@ impl StreamDeck {
 
         let _s = self.device.get_feature_report(&mut buff)?;
 
-        Ok(std::str::from_utf8(&buff[5..]).unwrap().to_string())
+        let offset = if self.kind.is_v2() { 6 } else { 5 };
+        Ok(std::str::from_utf8(&buff[offset..]).unwrap().to_string())
     }
 
     /// Reset the connected device


### PR DESCRIPTION
When requesting the firmware for v2 devices, we need discard the first 6
bytes, not 5 bytes as for the v1 devices.

This makes version calls on v2 devices work correctly. Tested on Streamdeck XL.