### PR TITLE
Public Constructor for ImageOptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+*.iml

--- a/src/images.rs
+++ b/src/images.rs
@@ -56,6 +56,12 @@ pub struct ImageOptions {
     invert: bool,
 }
 
+impl ImageOptions {
+    pub fn new(background: Option<Colour>, invert: bool) -> Self {
+        ImageOptions { background, invert }
+    }
+}
+
 impl Default for ImageOptions {
     fn default() -> Self {
         Self {


### PR DESCRIPTION
Added public constructor for image options, as without it, `set_button_file` could only use the `default()` ImageOption.

Now you can set background colours on transparent images 👍

(Snuck in an ignore for IntelliJ rust based project files too, hope you don't mind)