### PR TITLE
Add Clone to Colour

### DIFF
--- a/src/images.rs
+++ b/src/images.rs
@@ -9,7 +9,7 @@ use crate::info::{ColourOrder, Mirroring, Rotation};
 use crate::Error;
 
 /// Simple Colour object for re-writing backgrounds etc.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "structopt", derive(structopt::StructOpt))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Colour {


### PR DESCRIPTION
It's tricky to have a globally stored colour to reuse across multiple transparent image backgrounds without having a Clone operation.

So now there is one!