### PR TITLE
Add set_button_text() to create text buttons

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ default = [ "util" ]
 hidapi = "1.2"
 log = "0.4.8"
 image = "0.23.3"
+imageproc = "0.20.0"
+rusttype = "0.8.3"
 
 structopt = { version = "0.3.5", optional = true }
 simplelog = { version = "0.7.4", optional = true }


### PR DESCRIPTION
Adds the functionality to be able to dynamically generate button images and apply them based on text with a given font.

This includes text and background colouring, text scaling and positioning and support for line height over line breaks.

Adds dependencies on:
imageproc = "0.20.0"
rusttype = "0.8.3"