### PR TITLE
Add `connect_with_hid` to StreamDeck

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,16 @@ impl StreamDeck {
     pub fn connect(vid: u16, pid: u16, serial: Option<String>) -> Result<StreamDeck, Error> {
         // Create new API
         let api = HidApi::new()?;
+        StreamDeck::connect_with_hid(&api, vid, pid, serial)
+    }
 
+    /// Connect to a streamdeck device with an already initialise HidApi instance
+    pub fn connect_with_hid(
+        api: &HidApi,
+        vid: u16,
+        pid: u16,
+        serial: Option<String>,
+    ) -> Result<StreamDeck, Error> {
         // Match info based on PID
         let kind = match pid {
             pids::ORIGINAL => Kind::Original,


### PR DESCRIPTION
Since only one HidApi instance can exist at any given point and time, having an option to manage the lifecycle of that instance outside of StreamDeck is useful.

The example I needed this new function for was to enable reconnection scenarios, as I couldn't call `connect()` while I still had an instance of StreamDeck in scope, because `HidApi::new()?` would return an Error.