### PR TITLE
Add support for StreamDeck MK.2

### DIFF
--- a/src/info.rs
+++ b/src/info.rs
@@ -5,6 +5,7 @@ pub enum Kind {
     OriginalV2,
     Mini,
     Xl,
+    Mk2,
 }
 
 /// Stream Deck key layout direction
@@ -49,7 +50,7 @@ pub enum Mirroring {
 impl Kind {
     pub fn keys(&self) -> u8 {
         match self {
-            Kind::Original | Kind::OriginalV2 => 15,
+            Kind::Original | Kind::OriginalV2 | Kind::Mk2 => 15,
             Kind::Mini => 8,
             Kind::Xl => 32,
         }
@@ -59,7 +60,7 @@ impl Kind {
     pub(crate) fn key_data_offset(&self) -> usize {
         match self {
             Kind::Original => 0,
-            Kind::OriginalV2 => 3,
+            Kind::OriginalV2 | Kind::Mk2 => 3,
             Kind::Mini => 0,
             Kind::Xl => 3,
         }
@@ -75,7 +76,7 @@ impl Kind {
     pub(crate) fn key_columns(&self) -> u8 {
         match self {
             Kind::Mini => 3,
-            Kind::Original | Kind::OriginalV2 => 5,
+            Kind::Original | Kind::OriginalV2 | Kind::Mk2 => 5,
             Kind::Xl => 8,
         }
     }
@@ -83,13 +84,13 @@ impl Kind {
     pub fn image_mode(&self) -> ImageMode {
         match self {
             Kind::Original | Kind::Mini => ImageMode::Bmp,
-            Kind::OriginalV2 | Kind::Xl => ImageMode::Jpeg,
+            Kind::OriginalV2 | Kind::Xl | Kind::Mk2 => ImageMode::Jpeg,
         }
     }
 
     pub fn image_size(&self) -> (usize, usize) {
         match self {
-            Kind::Original | Kind::OriginalV2 => (72, 72),
+            Kind::Original | Kind::OriginalV2 | Kind::Mk2 => (72, 72),
             Kind::Mini => (80, 80),
             Kind::Xl => (96, 96),
         }
@@ -109,7 +110,7 @@ impl Kind {
             // On the original the image is flipped across the Y axis
             Kind::Original => Mirroring::Y,
             // On the V2 devices, both X and Y need to flip
-            Kind::OriginalV2 | Kind::Xl => Mirroring::Both,
+            Kind::OriginalV2 | Kind::Xl | Kind::Mk2 => Mirroring::Both,
         }
     }
 
@@ -128,7 +129,7 @@ impl Kind {
     pub(crate) fn image_report_header_len(&self) -> usize {
         match self {
             Kind::Original | Kind::Mini => 16,
-            Kind::OriginalV2 | Kind::Xl => 8,
+            Kind::OriginalV2 | Kind::Xl | Kind::Mk2 => 8,
         }
     }
 
@@ -138,20 +139,20 @@ impl Kind {
             Kind::Original => &ORIGINAL_IMAGE_BASE,
             Kind::Mini => &MINI_IMAGE_BASE,
 
-            Kind::OriginalV2 | Kind::Xl => &[],
+            Kind::OriginalV2 | Kind::Xl | Kind::Mk2 => &[],
         }
     }
 
     pub(crate) fn image_colour_order(&self) -> ColourOrder {
         match self {
             Kind::Original | Kind::Mini => ColourOrder::BGR,
-            Kind::OriginalV2 | Kind::Xl => ColourOrder::RGB,
+            Kind::OriginalV2 | Kind::Xl | Kind::Mk2 => ColourOrder::RGB,
         }
     }
 
     pub(crate) fn is_v2(&self) -> bool {
         match self {
-            Kind::OriginalV2 | Kind::Xl => true,
+            Kind::OriginalV2 | Kind::Xl | Kind::Mk2 => true,
             _ => false,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ pub mod pids {
     pub const ORIGINAL_V2: u16 = 0x006d;
     pub const MINI: u16 = 0x0063;
     pub const XL: u16 = 0x006c;
+    pub const MK2: u16 = 0x0080;
 }
 
 impl StreamDeck {
@@ -102,6 +103,7 @@ impl StreamDeck {
 
             pids::ORIGINAL_V2 => Kind::OriginalV2,
             pids::XL => Kind::Xl,
+            pids::MK2 => Kind::Mk2,
 
             _ => return Err(Error::UnrecognisedPID),
         };


### PR DESCRIPTION
The MK.2 as far as I can tell behaves exactly like the V2 (same protocol, buttons, resolution, orientation etc), just has updated hardware. But it has a new PID, so this PR adds it.

If you prefer I can also add a new `Kind` in case somebody wants to detect it, although just the PID is enough to tell the difference.