### PR TITLE
Make DeviceImage data be public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,22 @@ pub enum Error {
 }
 
 pub struct DeviceImage {
-    pub data: Vec<u8>,
+    data: Vec<u8>,
+}
+
+impl DeviceImage {
+    /// Constructs [DeviceImage] from a byte array
+    pub fn from_raw(data: Vec<u8>) -> Self {
+        Self::from(data)
+    }
+}
+
+impl From<Vec<u8>> for DeviceImage {
+    fn from(data: Vec<u8>) -> Self {
+        Self {
+            data
+        }
+    }
 }
 
 /// Device USB Product Identifiers (PIDs)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ pub enum Error {
 }
 
 pub struct DeviceImage {
-    data: Vec<u8>,
+    pub data: Vec<u8>,
 }
 
 /// Device USB Product Identifiers (PIDs)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ pub struct DeviceImage {
 
 impl DeviceImage {
     /// Constructs [DeviceImage] from a byte array
-    pub fn from_raw(data: Vec<u8>) -> Self {
+    pub fn from_bytes(data: Vec<u8>) -> Self {
         Self::from(data)
     }
 }


### PR DESCRIPTION
I'm currently trying to implement animated images with my project, but the whole overhead that set_button_image introduces makes it impossible. But write_button_image is also blocked since there's no way to construct DeviceImage struct outside of the crate. So I'm requesting this change, so projects like mine can manually prepare a valid byte buffer and push it to streamdeck with this library.