### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ default = [ "util" ]
 [dependencies]
 hidapi = "1.2"
 log = "0.4.8"
-image = "0.23.3"
-imageproc = "0.20.0"
-rusttype = "0.8.3"
+image = "0.24.3"
+imageproc = "0.23.0"
+rusttype = "0.9.2"
 thiserror = "1.0.30"
 
 structopt = { version = "0.3.5", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ rusttype = "0.8.3"
 thiserror = "1.0.30"
 
 structopt = { version = "0.3.5", optional = true }
-simplelog = { version = "0.7.4", optional = true }
-humantime = { version = "1.3.0", optional = true }
+simplelog = { version = "0.12.0", optional = true }
+humantime = { version = "2.1.0", optional = true }
 serde = { version = "1.0.104", optional = true, features = ["derive"] }
 
 [[bin]]

--- a/src/images.rs
+++ b/src/images.rs
@@ -1,12 +1,12 @@
 use std::str::FromStr;
 
 use image::io::Reader;
-use image::jpeg::JpegEncoder;
+use image::codecs::jpeg::JpegEncoder;
 use image::DynamicImage;
 use image::{imageops::FilterType, ColorType, Pixel, Rgba};
 
 use crate::info::{ColourOrder, Mirroring, Rotation};
-use crate::Error;
+use crate::{Error, rgb_to_bgr};
 
 /// Simple Colour object for re-writing backgrounds etc.
 #[derive(Debug, Clone)]
@@ -142,10 +142,11 @@ pub(crate) fn load_image(
     }
 
     // Convert to vector with correct encoding
-    let v = match colour_order {
-        ColourOrder::BGR => image.to_bgr8().into_vec(),
-        ColourOrder::RGB => image.to_rgb8().into_vec(),
-    };
+    let mut v= image.to_rgb8().into_vec();
+    if matches!(colour_order, ColourOrder::BGR) {
+        rgb_to_bgr(&mut v);
+    }
+
 
     if v.len() != x * y * 3 {
         return Err(Error::InvalidImageSize);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 
 #[macro_use] extern crate log;
 extern crate simplelog;
-use simplelog::{TermLogger, LevelFilter, TerminalMode};
+use simplelog::{TermLogger, LevelFilter, TerminalMode, ColorChoice};
 
 extern crate structopt;
 use structopt::StructOpt;
@@ -76,7 +76,7 @@ fn main() {
     let mut config = simplelog::ConfigBuilder::new();
     config.set_time_level(LevelFilter::Off);
 
-    TermLogger::init(opts.level, config.build(), TerminalMode::Mixed).unwrap();
+    TermLogger::init(opts.level, config.build(), TerminalMode::Mixed, ColorChoice::Auto).unwrap();
 
     // Connect to device
     let mut deck = match StreamDeck::connect(opts.filter.vid, opts.filter.pid, opts.filter.serial) {


### PR DESCRIPTION
This PR updates dependencies:
* `image`, `imageproc` and `rusttype` needed to be updated together because of shared dependencies
* also updated the optional dependencies `simplelog` and `humantime`
* in crate `image`, support for BGR color order has been removed (see https://github.com/image-rs/image/blob/master/CHANGES.md#version-0240). I added a small converter function when this order is needed

I tested this PR on my Stream Deck Mini and it works