### PR TITLE
Add probe function to detect connected devices

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,7 +213,10 @@ impl StreamDeck {
         Ok(())
     }
 
-    /// Probe for connected devices. Returns a list of tuples containing the device kind and PID
+    /// Probe for connected devices. 
+    /// 
+    /// Returns a list of results, 
+    /// each containing the device kind and PID or an error if the PID is unrecognised
     pub fn probe() -> Result<Vec<Result<(Kind, u16), Error>>, Error> {
         let api = HidApi::new()?;
         let mut available_devices = vec![];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,20 +214,21 @@ impl StreamDeck {
     }
 
     /// Probe for connected devices. Returns a list of tuples containing the device kind and PID
-    pub fn probe() -> Result<Vec<(Kind, u16)>, Error> {
+    pub fn probe() -> Result<Vec<Result<(Kind, u16), Error>>, Error> {
         let api = HidApi::new()?;
-        let mut available_devices: Vec<(Kind, u16)> = vec![];
+        let mut available_devices = vec![];
         for device in api.device_list() {
-            if device.vendor_id() == 0x0fd9 { // Elgato Vendor ID
-                match device.product_id() {
-                    pids::MK2 => available_devices.push((Kind::Mk2, pids::MK2)),
-                    pids::XL => available_devices.push((Kind::Xl, pids::XL)),
-                    pids::ORIGINAL_V2 => available_devices.push((Kind::OriginalV2, pids::ORIGINAL_V2)),
-                    pids::ORIGINAL => available_devices.push((Kind::Original, pids::ORIGINAL)),
-                    pids::MINI => available_devices.push((Kind::Mini, pids::MINI)),
-                    _ => {} // Should we error here? We would need to return a vector of results then.
-                            // I'd prefer a warn! log message.
+            if device.vendor_id() == 0x0fd9 {
+                let deck = match device.product_id() {
+                    pids::MK2 => Ok((Kind::Mk2, pids::MK2)),
+                    pids::XL => Ok((Kind::Xl, pids::XL)),
+                    pids::ORIGINAL_V2 => Ok((Kind::OriginalV2, pids::ORIGINAL_V2)),
+                    pids::ORIGINAL => Ok((Kind::Original, pids::ORIGINAL)),
+                    pids::MINI => Ok((Kind::Mini, pids::MINI)),
+                    //pids::PLUS => Ok((Kind::Plus, pids::PLUS)),
+                    _ => Err(Error::UnrecognisedPID)
                 };
+                available_devices.push(deck);
             }
         }
         Ok(available_devices)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,6 +213,26 @@ impl StreamDeck {
         Ok(())
     }
 
+    /// Probe for connected devices. Returns a list of tuples containing the device kind and PID
+    pub fn probe() -> Result<Vec<(Kind, u16)>, Error> {
+        let api = HidApi::new()?;
+        let mut available_devices: Vec<(Kind, u16)> = vec![];
+        for device in api.device_list() {
+            if device.vendor_id() == 0x0fd9 { // Elgato Vendor ID
+                match device.product_id() {
+                    pids::MK2 => available_devices.push((Kind::Mk2, pids::MK2)),
+                    pids::XL => available_devices.push((Kind::Xl, pids::XL)),
+                    pids::ORIGINAL_V2 => available_devices.push((Kind::OriginalV2, pids::ORIGINAL_V2)),
+                    pids::ORIGINAL => available_devices.push((Kind::Original, pids::ORIGINAL)),
+                    pids::MINI => available_devices.push((Kind::Mini, pids::MINI)),
+                    _ => {} // Should we error here? We would need to return a vector of results then.
+                            // I'd prefer a warn! log message.
+                };
+            }
+        }
+        Ok(available_devices)
+    }
+
     /// Fetch button states
     ///
     /// In blocking mode this will wait until a report packet has been received

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,8 @@ pub enum Commands {
     Reset,
     /// Fetch the device firmware version
     Version,
+    /// Search for connected streamdecks
+    Probe,
     /// Set device display brightness
     SetBrightness{
         /// Brightness value from 0 to 100
@@ -119,6 +121,20 @@ fn do_command(deck: &mut StreamDeck, cmd: Commands) -> Result<(), Error> {
                 }
             }
         },
+        Commands::Probe => {
+            let results = StreamDeck::probe()?;
+            if results.is_empty() {
+                info!("No devices found");
+                return Ok(());
+            }
+            info!("Found {} devices", results.len());
+            for res in results {
+                match res {
+                    Ok((device, pid)) => info!("Streamdeck: {:?} (pid: {:#x})", device, pid),
+                    Err(_) => warn!("Found Elgato device with unsupported PID"),
+                }
+            }
+        }
         Commands::SetColour{key, colour} => {
             info!("Setting key {} colour to: ({:?})", key, colour);
             deck.set_button_rgb(key, &colour)?;


### PR DESCRIPTION
- Added probe fn to StreamDeck struct
- Added cli command

As mentioned in #33, CLI currently requires a pid which it immediatly connects to, so the usefulness of the feature is limited at the moment.